### PR TITLE
feat(auth): Implement HTTP-only cookies for JWT authentication

### DIFF
--- a/backend/src/main/java/com/markethub/controller/AuthController.java
+++ b/backend/src/main/java/com/markethub/controller/AuthController.java
@@ -4,9 +4,13 @@ import com.markethub.dto.AuthResponse;
 import com.markethub.dto.LoginRequest;
 import com.markethub.dto.RegisterRequest;
 import com.markethub.service.AuthService;
-import jakarta.validation.Valid;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,21 +18,88 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-
     private final AuthService authService;
 
+    @Value("${application.security.jwt.expiration}")
+    private long jwtExpiration;
+
+    @Value("${application.security.jwt.refresh-token.expiration}")
+    private long refreshExpiration;
+
     @PostMapping("/register")
-    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
-        return ResponseEntity.ok(authService.register(request));
+    public ResponseEntity<AuthResponse> register(
+            @RequestBody RegisterRequest request,
+            HttpServletResponse response
+    ) {
+        AuthResponse authResponse = authService.register(request);
+        setTokenCookies(response, authResponse.getAccessToken(), authResponse.getRefreshToken());
+
+        authResponse.setAccessToken(null);
+        authResponse.setRefreshToken(null);
+
+        return ResponseEntity.ok(authResponse);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<AuthResponse> login(
+            @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        AuthResponse authResponse = authService.login(request);
+        setTokenCookies(response, authResponse.getAccessToken(), authResponse.getRefreshToken());
+
+        authResponse.setAccessToken(null);
+        authResponse.setRefreshToken(null);
+
+        return ResponseEntity.ok(authResponse);
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<AuthResponse> refresh(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
-        return ResponseEntity.ok(authService.refreshToken(authHeader));
+    public ResponseEntity<AuthResponse> refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = null;
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refresh_token".equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if (refreshToken == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        AuthResponse authResponse = authService.refreshToken(refreshToken);
+
+        setTokenCookies(response, authResponse.getAccessToken(), authResponse.getRefreshToken());
+
+        authResponse.setAccessToken(null);
+        authResponse.setRefreshToken(null);
+
+        return ResponseEntity.ok(authResponse);
+    }
+
+    private void setTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", accessToken)
+                .httpOnly(true)
+                .secure(false)        // 'true' for HTTPS in production
+                .path("/")
+                .maxAge(jwtExpiration / 1000)
+                .sameSite("Strict")
+                .build();
+
+        // Cookie de Refresh Token
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(refreshExpiration / 1000)
+                .sameSite("Strict")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     }
 }

--- a/backend/src/main/java/com/markethub/dto/AuthResponse.java
+++ b/backend/src/main/java/com/markethub/dto/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.markethub.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,7 +10,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthResponse {
     private String accessToken;
     private String refreshToken;
+    private String userName;
+    private String email;
+    private String role;
 }

--- a/backend/src/main/java/com/markethub/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/markethub/security/JwtAuthFilter.java
@@ -2,6 +2,7 @@ package com.markethub.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,16 +29,24 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        final String authHeader = request.getHeader("Authorization");
-        final String jwt;
+
+        String jwt = null;
         final String userEmail;
 
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("access_token".equals(cookie.getName())) {
+                    jwt = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if (jwt == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        jwt = authHeader.substring(7);
         userEmail = jwtService.extractUsername(jwt);
 
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/backend/src/main/java/com/markethub/service/AuthService.java
+++ b/backend/src/main/java/com/markethub/service/AuthService.java
@@ -59,11 +59,13 @@ public class AuthService {
                 .build();
     }
 
-    public AuthResponse refreshToken(String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Token inválido");
+    public AuthResponse refreshToken(String token) {
+        if (token == null) {
+            throw new IllegalArgumentException("Token was not provided");
         }
-        final String refreshToken = authHeader.substring(7);
+
+        final String refreshToken = token.startsWith("Bearer ") ? token.substring(7) : token;
+
         final String userEmail = jwtService.extractUsername(refreshToken);
 
         if (userEmail != null) {
@@ -76,6 +78,6 @@ public class AuthService {
                         .build();
             }
         }
-        throw new IllegalArgumentException("Token expirado o inválido");
+        throw new IllegalArgumentException("Token expired or invalid");
     }
 }


### PR DESCRIPTION
- Update AuthController to set access and refresh tokens in HTTP-only cookies which improves security.
- Modify JwtAuthFilter to extract the access_token directly from cookies instead of the Authorization header.
- Refactor AuthService to handle raw tokens and update error messages.
- Update AuthResponse DTO to include user details (name, email, role) and exclude null token fields from the JSON body.

Closes #3