### PR TITLE
feat: add application-dev.properties and application-prod.properties

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,15 @@
+# Postgresql
+spring.datasource.url=jdbc:postgresql://postgres:5432/markethubdb
+spring.datasource.username=roots
+spring.datasource.password=roots
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# ORM
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# JWT
+application.security.jwt.secret-key=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
+application.security.jwt.expiration=86400000
+application.security.jwt.refresh-token.expiration=604800000

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,0 +1,15 @@
+# Postgresql
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# ORM
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# JWT
+application.security.jwt.secret-key=
+application.security.jwt.expiration=
+application.security.jwt.refresh-token.expiration=

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,15 +1,1 @@
-# Postgresql
-spring.datasource.url=jdbc:postgresql://postgres:5432/markethubdb
-spring.datasource.username=roots
-spring.datasource.password=roots
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-# ORM
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-
-# JWT
-application.security.jwt.secret-key=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
-application.security.jwt.expiration=86400000
-application.security.jwt.refresh-token.expiration=604800000
+spring.profiles.active=dev


### PR DESCRIPTION
Add the application-dev.properties and application-prod.properties configuration files that are used for Spring Boot profiles.

Specify which profile you want to use in application.properties with the line `spring.profiles.active={prod | dev}` or by using an environment variable in Docker Compose `SPRING_PROFILES_ACTIVE: {prod | dev}`.